### PR TITLE
prepare to enable ssl

### DIFF
--- a/SOURCES/init.d-graylog2-web
+++ b/SOURCES/init.d-graylog2-web
@@ -34,7 +34,7 @@ RUN=no
 start() {
     echo -n $"Starting ${NAME}: "
     daemon --user=$GL_USER \
-        nohup $CMD -Dconfig.file=${CONF_FILE} > /var/log/graylog2/web.log 2>&1 &
+        nohup $CMD -Dconfig.file=${CONF_FILE} $JAVA_EXTRA_ARGS > /var/log/graylog2/web.log 2>&1 &
     RETVAL=$?
     echo 
     sleep 2

--- a/SOURCES/sysconfig-graylog2-web
+++ b/SOURCES/sysconfig-graylog2-web
@@ -5,3 +5,5 @@
 #User to run graylog2 as
 #GL_USER=graylog2
 #CONF_FILE=/etc/graylog2/web.conf
+#JAVA_EXTRA_ARGS="-Dhttps.port=9443 -Dhttp.port=disabled"
+


### PR DESCRIPTION
Use JAVA_EXTRA_ARGS to allow to add more Parameters to java to make ssl
enablement easier
